### PR TITLE
Fixed fractional angles getting floored. Bump version?

### DIFF
--- a/InfiniteNudge/InfiniteNudge.uplugin
+++ b/InfiniteNudge/InfiniteNudge.uplugin
@@ -1,8 +1,8 @@
 {
 	"FileVersion": 3,
 	"Version": 2,
-	"VersionName": "2.1.1",
-	"SemVersion": "2.1.1",
+	"VersionName": "2.1.2",
+	"SemVersion": "2.1.2",
 	"FriendlyName": "Infinite Nudge",
 	"Description": "Nudge forever, vertically, in smaller increments, and rotate on any axis. Also nudge extractors!",
 	"Category": "Modding",

--- a/InfiniteNudge/Source/InfiniteNudge/Private/InfiniteNudgeModule.cpp
+++ b/InfiniteNudge/Source/InfiniteNudge/Private/InfiniteNudgeModule.cpp
@@ -445,7 +445,7 @@ void FInfiniteNudgeModule::RotateLockedHologram(AFGHologram* self, int32 delta)
 
 		//auto newRotation = self->GetActorRotation();
 		auto newRotation = FRotator(0, 0, 0);
-		int rotationAmount = 15 * delta;
+		double rotationAmount = 15.0 * delta;
 
 		// Set Fine Rotation
 		if (contr->IsInputKeyDown(TinyNudgeKey))


### PR DESCRIPTION
as discussed in Discord #bugs, it was impossible to set rotation angles more accurately than 1°.
Somehow the configuration system still reduces the possible accuracy to 3 decimal places, but for now a 1000x increase in accuracy should do.