### PR TITLE
InfiniteNudge: Fix building with C++20

### DIFF
--- a/InfiniteNudge/Source/InfiniteNudge/Public/InfiniteNudgeModule.h
+++ b/InfiniteNudge/Source/InfiniteNudge/Public/InfiniteNudgeModule.h
@@ -15,16 +15,14 @@ public:
 
 	virtual bool IsGameModule() const override { return true; }
 
-	FVector NudgeTowardsWorldDirection(AFGHologram* self, const FVector& Direction);
+	static FVector NudgeTowardsWorldDirection(AFGHologram* self, const FVector& Direction);
 
-	void NudgeHologram(const AFGHologram* self, const FVector& NudgeInput, const FHitResult& HitResult);
-	void NudgeGenericHologram(const AFGGenericBuildableHologram* self, const FVector& NudgeInput, const FHitResult& HitResult);
-	FVector AddNudgeOffset(AFGHologram* self, const FVector& Direction);
+	static void NudgeHologram(const AFGHologram* self, const FVector& NudgeInput, const FHitResult& HitResult);
+	static void NudgeGenericHologram(const AFGGenericBuildableHologram* self, const FVector& NudgeInput, const FHitResult& HitResult);
+	static FVector AddNudgeOffset(AFGHologram* self, const FVector& Direction);
 
-	void RotateLockedHologram(AFGHologram* self, int32 delta);
-	void ScaleHologram(AFGHologram* self);
+	static void RotateLockedHologram(AFGHologram* self, int32 delta);
+	static void ScaleHologram(AFGHologram* self);
 
-	void DebugChecker();
-
-	float savedNudgeDistance;
+	static void DebugChecker();
 };


### PR DESCRIPTION
Make everything static to avoid errors about implicitly capturing `this` in hooks.