### PR TITLE
Fixed upgrading scaled signals

### DIFF
--- a/InfiniteNudge/Source/InfiniteNudge/Private/InfiniteNudgeModule.cpp
+++ b/InfiniteNudge/Source/InfiniteNudge/Private/InfiniteNudgeModule.cpp
@@ -95,15 +95,17 @@ void FInfiniteNudgeModule::StartupModule() {
 		{
 			float Scale = 1.0f;
 			bool isLeftHanded = false;
+			class AFGBuildableRailroadSignal* UpgradeTarget = nullptr;
 
 			if (self && self->GetRootComponent())
 			{
 				FVector ScaleVec = self->GetRootComponent()->GetComponentScale();
 				Scale = (ScaleVec.X + ScaleVec.Y + ScaleVec.Z) / 3.0f;
 				isLeftHanded = self->mIsLeftHanded;
+				UpgradeTarget = self->mUpgradeTarget;
 			}
 
-			if (inBuildable)
+			if (inBuildable && !UpgradeTarget)
 			{
 				float yLocation = -280.0f * Scale + 280.0f;
 


### PR DESCRIPTION
Added a check to the hologram hook to only apply the location offset when initially building a signal, not when upgrading it.