### PR TITLE
Guard Infinite Zoop subsystem updates

### DIFF
--- a/InfiniteZoop/Source/InfiniteZoop/Private/InfiniteZoopModule.cpp
+++ b/InfiniteZoop/Source/InfiniteZoop/Private/InfiniteZoopModule.cpp
@@ -1058,8 +1058,25 @@ void FInfiniteZoopModule::SetSubsystemZoopAmounts(int x, int y, int z, bool isFo
 		return;
 	}*/
 
+	if (!world || !hologram)
+	{
+		return;
+	}
 	USubsystemActorManager* SubsystemActorManager = world->GetSubsystem<USubsystemActorManager>();
+	if (!SubsystemActorManager)
+	{
+		return;
+	}
 	AInfiniteZoopSubsystem* zoopSubsystem = SubsystemActorManager->GetSubsystemActor<AInfiniteZoopSubsystem>();
+	if (!zoopSubsystem)
+	{
+		return;
+	}
+	APawn* constructionInstigator = hologram->GetConstructionInstigator();
+	if (!constructionInstigator)
+	{
+		return;
+	}
 	bool isZoopMode = false;
 	bool isVerticalMode = false;
 	if (isFoundation)
@@ -1088,7 +1105,7 @@ void FInfiniteZoopModule::SetSubsystemZoopAmounts(int x, int y, int z, bool isFo
 	}
 	if (!isZoopMode)
 	{
-		zoopSubsystem->SetPublicZoopAmount(-1, -1, -1, isFoundation, isVerticalMode, hologram->GetConstructionInstigator(), lockObj);
+		zoopSubsystem->SetPublicZoopAmount(-1, -1, -1, isFoundation, isVerticalMode, constructionInstigator, lockObj);
 		zoopSubsystem->ForceNetUpdate();
 		return;
 	}
@@ -1117,10 +1134,10 @@ void FInfiniteZoopModule::SetSubsystemZoopAmounts(int x, int y, int z, bool isFo
 
 	if (newX == 2 && newY == 2 && newZ == 2)
 	{
-		zoopSubsystem->SetPublicZoopAmount(-1, -1, -1, isFoundation, isVerticalMode, hologram->GetConstructionInstigator(), lockObj);
+		zoopSubsystem->SetPublicZoopAmount(-1, -1, -1, isFoundation, isVerticalMode, constructionInstigator, lockObj);
 		return;
 	}
-	zoopSubsystem->SetPublicZoopAmount(newX, newY, newZ, isFoundation, isVerticalMode, hologram->GetConstructionInstigator(), lockObj);
+	zoopSubsystem->SetPublicZoopAmount(newX, newY, newZ, isFoundation, isVerticalMode, constructionInstigator, lockObj);
 	zoopSubsystem->ForceNetUpdate();
 }
 #pragma optimize("", on)

--- a/InfiniteZoop/Source/InfiniteZoop/Private/InfiniteZoopSubsystem.cpp
+++ b/InfiniteZoop/Source/InfiniteZoop/Private/InfiniteZoopSubsystem.cpp
@@ -18,45 +18,47 @@ void AInfiniteZoopSubsystem::GetLifetimeReplicatedProps(TArray<FLifetimeProperty
 void AInfiniteZoopSubsystem::SetPublicZoopAmount(int x, int y, int z, bool foundation, bool verticalZoop, APawn* owner, FCriticalSection* lockObj)
 {
 	//UE_LOGFMT(InfiniteZoop_Log, Display, "AInfiniteZoopSubsystem::SetPublicZoopAmount: {0},{1},{2}", x, y, z);
-	if (lockObj && lockObj->TryLock())
+	if (!lockObj || !lockObj->TryLock())
 	{
-		if (!owner)
-		{
-			return;
-		}
-		FZoopAmountStruct zStruct;
-		if (ZoopAmountStructs.Num() > 0 && ZoopAmountStructs.Contains(owner))
-		{
-			zStruct = ZoopAmountStructs[owner];
-		}
-		zStruct.isFoundation = foundation;
-		if (foundation && verticalZoop)
-		{
-			zStruct.xAmount = -1;
-			zStruct.zAmount = -1;
-			zStruct.yAmount = -1;
-			zStruct.needsUpdate = true;
-			ZoopAmountStructs.Add(owner, zStruct);
-			return;
-		}
-		if (x == xAmount && y == yAmount && z == zAmount && foundation == isFoundation)
-		{
-			zStruct.xAmount = -1;
-			zStruct.zAmount = -1;
-			zStruct.yAmount = -1;
-			zStruct.isFoundation = foundation;
-			needsUpdate = false;
-		}
-		else
-		{
-			zStruct.xAmount = x;
-			zStruct.yAmount = y;
-			zStruct.zAmount = z;
-			zStruct.isFoundation = foundation;
-			zStruct.needsUpdate = true;
-		}
-		ZoopAmountStructs.Add(owner, zStruct);
-		ForceNetUpdate();
-		lockObj->Unlock();
+		return;
 	}
+
+	if (!owner)
+	{
+		lockObj->Unlock();
+		return;
+	}
+
+	FZoopAmountStruct zStruct;
+	if (ZoopAmountStructs.Num() > 0 && ZoopAmountStructs.Contains(owner))
+	{
+		zStruct = ZoopAmountStructs[owner];
+	}
+	zStruct.isFoundation = foundation;
+	if (foundation && verticalZoop)
+	{
+		zStruct.xAmount = -1;
+		zStruct.zAmount = -1;
+		zStruct.yAmount = -1;
+		zStruct.needsUpdate = true;
+	}
+	else if (x == xAmount && y == yAmount && z == zAmount && foundation == isFoundation)
+	{
+		zStruct.xAmount = -1;
+		zStruct.zAmount = -1;
+		zStruct.yAmount = -1;
+		zStruct.isFoundation = foundation;
+		needsUpdate = false;
+	}
+	else
+	{
+		zStruct.xAmount = x;
+		zStruct.yAmount = y;
+		zStruct.zAmount = z;
+		zStruct.isFoundation = foundation;
+		zStruct.needsUpdate = true;
+	}
+	ZoopAmountStructs.Add(owner, zStruct);
+	ForceNetUpdate();
+	lockObj->Unlock();
 }


### PR DESCRIPTION
## Summary

This hardens Infinite Zoop's build-gun subsystem update path against missing world/subsystem/hologram state.

The crash seen in Satisfactory 1.2 (`CL 491125`, SML `3.12.0`) happens through:

```text
AInfiniteZoopSubsystem::SetPublicZoopAmount()
FInfiniteZoopModule::SetSubsystemZoopAmounts()
FInfiniteZoopModule::BGSecondaryFire()
UFGBuildGunState::SecondaryFire
AFGBuildGun::Input_SecondaryFire()
```

In affected runtime logs, the native Infinite Zoop module loads, but `/Script/InfiniteZoop.InfiniteZoopSubsystem` is not registered. `SetSubsystemZoopAmounts()` then assumes the subsystem actor exists and calls `SetPublicZoopAmount()` through a null pointer, producing an access violation at address `0x00000000000002c0`.

## Changes

- Return early from `SetSubsystemZoopAmounts()` if the world, hologram, subsystem actor manager, Infinite Zoop subsystem, or construction instigator is unavailable.
- Reuse the validated construction instigator for all `SetPublicZoopAmount()` calls.
- Make `SetPublicZoopAmount()` release the provided critical section before returning when `owner` is null.
- Avoid leaving the critical section locked in the vertical zoop branch by using a single write/update/unlock path.

## Validation

- Ran `git diff --check`.
- Inspected the reported crash path against the guarded code path.
- Could not compile locally because this checkout does not include a configured Satisfactory/Unreal mod build environment.

## Notes

This prevents the native hook from crashing when the subsystem is missing. It does not by itself explain why the Infinite Zoop world module/subsystem is sometimes absent after the 1.2 GameFeature/SML 3.12 migration, so there may still be a packaging or asset-registration issue to investigate separately.
